### PR TITLE
Update SphinxSearch.php

### DIFF
--- a/src/Scalia/SphinxSearch/SphinxSearch.php
+++ b/src/Scalia/SphinxSearch/SphinxSearch.php
@@ -155,7 +155,10 @@ class SphinxSearch {
         foreach($matchids as $matchid)
         {
           $key = self::getResultKeyByID($matchid, $result);
-          $return_val[] = $result[$key];
+          if($key !== false)
+          {
+            $return_val[] = $result[$key];
+          }
         }
         return $return_val;  
       }


### PR DESCRIPTION
If the getResultKeyByID returns a false, $result[$key] grabs the first item in the array which ends up returning the wrong result set.  This resolves that issue.
