### PR TITLE
Allow closures when eager loading

### DIFF
--- a/src/Scalia/SphinxSearch/SphinxSearch.php
+++ b/src/Scalia/SphinxSearch/SphinxSearch.php
@@ -189,11 +189,19 @@ class SphinxSearch {
 
   public function with()
   {
-    $this->_eager_loads = array();
+    // Allow multiple with-calls
+    if (false === isset($this->_eager_loads)) {
+      $this->_eager_loads = array();
+    }
 
     foreach (func_get_args() as $a)
     {
-      $this->_eager_loads[] = $a;
+      // Add closures as name=>function()
+      if (is_array($a)) {
+        $this->_eager_loads = array_merge($this->_eager_loads, $a);
+      } else {
+        $this->_eager_loads[] = $a;
+      }
     }
 
     return $this;


### PR DESCRIPTION
Eloquent allows adding constraints to eager loading like this:
```php
$users = User::with(array('posts' => function($query)
{
    $query->where('title', 'like', '%first%');

}))->get();
```
The with() function takes either an array of strings or an associative array where keys are string names and values are closures. I've added this to the SphinxSearch class. Is there a good reason to reset the _eager_loads field each time you call with()?