### PR TITLE
Make the service provider deferred

### DIFF
--- a/src/Scalia/SphinxSearch/SphinxSearchServiceProvider.php
+++ b/src/Scalia/SphinxSearch/SphinxSearchServiceProvider.php
@@ -9,7 +9,7 @@ class SphinxSearchServiceProvider extends ServiceProvider {
 	 *
 	 * @var bool
 	 */
-	protected $defer = false;
+	protected $defer = true;
 
 	/**
 	 * Bootstrap the application events.


### PR DESCRIPTION
This will avoid loading the service provider (and connecting to the Sphinx server) until the provider is actually used. Since most applications will only use the provider on a fraction of pages, it should result in an overall performance increase.
See the [deferred providers](http://laravel.com/docs/4.2/packages#deferred-providers) info in the Laravel documentation.